### PR TITLE
falling back to HTTP if no certificate is found

### DIFF
--- a/backend/configure-ssl.js
+++ b/backend/configure-ssl.js
@@ -27,14 +27,14 @@ module.exports = (app) => {
       var credentials = {key: privateKey, cert: certificate}
       server = https.createServer(credentials, app)
     } catch (err) {
-		if (err.code === 'ENOENT') {
-		  console.log("no TLS certificate at", err.path)
-		  var http = require('http')
-          server = http.createServer(app)
-	    } else {
-          throw err
-		}
-	}
+      if (err.code === 'ENOENT') {
+        console.log("no TLS certificate at", err.path)
+        var http = require('http')
+        server = http.createServer(app)
+      } else {
+        throw err
+      }
+    }
   }
 
   return server


### PR DESCRIPTION
Hi Olivia,

I added a fallback to plain old HTTP when no certificate file is found. This is useful when you want to run hydra locally and do not want to deal with setting up TLS for things served from localhost.

Cheers,
tpltnt