### PR TITLE
cmd key to work as well as ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ install dependencies:
 ```
 yarn install
 ```
+build:
+```
+pushd .
+cd frontend/web-editor
+yarn build
+popd
+```
 run server
 ```
 yarn serve

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ synth = new Tone.Synth().toDestination();
 synth.triggerAttackRelease("C4", "8n");
 ```
 ## Running locally
-To run locally, you must have nodejs, yarn and npm installed. Install node and npm from: https://nodejs.org/en/. Once you have node and npm installed, you can install yarn globally by running the following from the command line:
+To run locally, you must have nodejs, yarn and npm installed. Install node and npm from: https://nodejs.org/en/ (nodejs >= 14.0.0 required). Once you have node and npm installed, you can install yarn globally by running the following from the command line:
 ```
 npm install --global yarn
 ```

--- a/frontend/web-editor/src/views/editor/keymaps.js
+++ b/frontend/web-editor/src/views/editor/keymaps.js
@@ -1,11 +1,19 @@
 module.exports = { 
     'Ctrl-Enter': 'editor:evalLine',
+    'Cmd-Enter': 'editor:evalLine',
     'Ctrl-/': 'editor:toggleComment',
+    'Cmd-/': 'editor:toggleComment',
     'Alt-Enter': 'editor:evalBlock',
     'Shift-Ctrl-Enter': 'editor:evalAll',
+    'Shift-Cmd-Enter': 'editor:evalAll',
     'Shift-Ctrl-G': 'gallery:shareSketch',
+    'Shift-Cmd-G': 'gallery:shareSketch',
     'Shift-Ctrl-F': 'editor:formatCode',
+    'Shift-Cmd-F': 'editor:formatCode',
     'Shift-Ctrl-L': 'gallery:saveToURL',
+    'Shift-Cmd-L': 'gallery:saveToURL',
     'Shift-Ctrl-H': 'hideAll',
-    'Shift-Ctrl-S': 'screencap'
+    'Shift-Cmd-H': 'hideAll',
+    'Shift-Ctrl-S': 'screencap',
+    'Shift-Cmd-S': 'screencap'
 }


### PR DESCRIPTION
especially for mac, with this keymap, command key works as well (e.g., command+enter to evaluate line). Ctrl works as it used to be, too.

Problem is that I have errors (issue #247) that I cannot build the bundle. I did edit the old bundle file and tested it in a ghetto way: https://hydra.glitches.me

I haven't edited changelog/version yet